### PR TITLE
Update Media (big).ini to fix scaling issues

### DIFF
--- a/Media/Media (big).ini
+++ b/Media/Media (big).ini
@@ -72,7 +72,7 @@ UpdateDivider=10
 Meter=String
 MeasureName=MeasureTrack
 MeterStyle=StyleSecondary
-X=(#Margin#*#Scale#)+(115+#Scale#)
+X=(#Margin#*#Scale#)+(115*#Scale#)
 Y=(35*#Scale#)
 W=((#Width#-135)*#Scale#)
 UpdateDivider=10
@@ -152,10 +152,10 @@ ImageTint=#MainColor#
 
 [MeterProgress]
 Meter=Shape
-X=(#Margin#*#Scale#+115)
+X=(#Margin#*#Scale#+115*#Scale#)
 Y=(135*#Scale#)
-Shape=Rectangle 0,0,(#Width#*#Scale#-115),(4*#Scale#),(2*#Scale#) | Fill Color #MainColor#,50 | StrokeWidth 0
-Shape2=Rectangle 0,0,((#Width#*#Scale#-115)*([MeasureProgress]/100)),(4*#Scale#),(2*#Scale#) | Fill Color #MainColor#,245 | StrokeWidth 0
+Shape=Rectangle 0,0,(#Width#*#Scale#-115*#Scale#),(4*#Scale#),(2*#Scale#) | Fill Color #MainColor#,50 | StrokeWidth 0
+Shape2=Rectangle 0,0,((#Width#*#Scale#-115*#Scale#)*([MeasureProgress]/100)),(4*#Scale#),(2*#Scale#) | Fill Color #MainColor#,245 | StrokeWidth 0
 DynamicVariables=1
 UpdateDivider=10
 Padding=0,0,0,(20*#Scale#)


### PR DESCRIPTION
Fixed some elements not moving in accordance with changes in scale, which resulted in the track info and progress bar moving towards (and eventually overlapping) the album art and playback controls on scales higher than 1 and moving away from them on scales lower than 1.