### PR TITLE
Use substitutions to adapt to OpenWeather's icon code change

### DIFF
--- a/Weather/weather.ini
+++ b/Weather/weather.ini
@@ -57,7 +57,7 @@ Measure=Plugin
 Plugin=WebParser
 URL=[MeasureWeather]
 StringIndex=10
-Substitute="":"na"
+Substitute="01d":"32","01n":"31","02d":"28","02n":"27","03d":"26","03n":"26","04d":"19","04n":"19","09d":"13","09n":"13","10d":"17","10n":"17","11d":"37","11n":"37","13d":"25","13n":"25","50d":"19","50n":"19","":"na"
 [MeasureCurrentCode]
 Measure=Plugin
 Plugin=WebParser


### PR DESCRIPTION
This could be a temporary fix to adapt to the new set of icons used by OpenWeather while still using the existing assets for the time being.
Could be rough but it kinda works (I guess).