### PR TITLE
Fix temperature readings (HWInfo v7.0)

### DIFF
--- a/Temperature/CPU/cputemp.ini
+++ b/Temperature/CPU/cputemp.ini
@@ -29,24 +29,20 @@ Information=An minimalistic, still stylish dashboard-like skin with modular comp
 
 ; CPU temperature measures
 [MeasureCPUTempRaw]
-Measure=Plugin
-Plugin=HWiNFO
-HWiNFOSensorId=#CPUSensorId#
-HWiNFOSensorInstance=#CPUSensorInstance#
-HWiNFOEntryId=#CPUEntryId#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRawX ; CHANGE X FOR YOUR NUMBER
 
 [MeasureCPUTemp]
 Measure=Calc
 Formula=MeasureCPUTempRaw+#CPUOffset#
 
 [MeasureCPUName]
-Measure=Plugin
-Plugin=HWiNFO
-HWiNFOSensorId=#CPUSensorId#
-HWiNFOSensorInstance=#CPUSensorInstance#
-HWiNFOType=SensorName
-HWiNFOLogHandler=3
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=SensorX ; CHANGE X FOR YOUR NUMBER
 RegExpSubstitute=1
 Substitute="^(.*]: )":"","(: .*)$":"","HWI_ERROR_SENSOR_NOT_FOUND":"Error#CRLF#Sensor not found","HWI_ERROR_NOT_CONNECTED":"Error#CRLF#HWiNFO not found","(Intel Core|Intel\(R\) Core)":"Intel(R) Core#CRLF#","AMD":"AMD#CRLF#"
 UpdateDivider=-1

--- a/Temperature/GPU/gputemp.ini
+++ b/Temperature/GPU/gputemp.ini
@@ -29,20 +29,16 @@ Information=An minimalistic, still stylish dashboard-like skin with modular comp
 @include2=#@#include\MeterStyles.inc
 
 [MeasureGPUTemp]
-Measure=Plugin
-Plugin=HWiNFO
-HWiNFOSensorId=#GPUSensorId#
-HWiNFOSensorInstance=#GPUSensorInstance#
-HWiNFOEntryId=#GPUEntryId#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRawY; CHANGE Y FOR YOUR VALUE
 
 [MeasureGPUName]
-Measure=Plugin
-Plugin=HWiNFO
-HWiNFOSensorId=#GPUSensorId#
-HWiNFOSensorInstance=#GPUSensorInstance#
-HWiNFOType=SensorName
-HWiNFOLogHandler=3
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=SensorY; CHANGE Y FOR YOUR VALUE
 RegExpSubstitute=1
 Substitute="^(.*]: )":"","(: .*)$":"","HWI_ERROR_SENSOR_NOT_FOUND":"Error#CRLF#Sensor not found","HWI_ERROR_NOT_CONNECTED":"Error#CRLF#HWiNFO not found","AMD Radeon":"AMD Radeon#CRLF#","NVIDIA GeForce":"NVIDIA GeForce#CRLF#","Intel\(R\)":"Intel(R) #CRLF#"
 UpdateDivider=-1


### PR DESCRIPTION
Fixes issue #63. Requires manual configuration but there's nothing I can do about it since your indices may not be (and probably won't be) the same as mine.

